### PR TITLE
chore: relax node requirement to 20.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "muhammara": "^5.3.0"
   },
   "engines": {
-    "node": ">= 20.19.0"
+    "node": ">= 20.18.1"
   },
   "overrides": {
     "semver": "7.5.4"


### PR DESCRIPTION
Hello lambda-muhammara maintainers!

I noticed that the minimum Node version might be a little too strict (currently set to `>= 20.19.0`).

Feel free to close this if this behavior is intentional.

